### PR TITLE
fix(utils): remove sudo from `run_powermetrics_process` function

### DIFF
--- a/mxtop/utils.py
+++ b/mxtop/utils.py
@@ -194,13 +194,15 @@ def run_powermetrics_process(
     # Absolute paths: this runs as root, and macOS sudo does not set
     # secure_path, so $PATH is still the invoking user's.
     cmd = [
-        "/usr/bin/sudo", "/usr/bin/nice", f"-n{nice}",
+        "/usr/bin/nice", f"-n{nice}",
         "/usr/bin/powermetrics",
         "--samplers", "cpu_power,gpu_power,thermal",
         "-o", f"{_TMP_PREFIX}{timecode}",
         "-f", "plist",
         "-i", str(interval),
     ]
+    if os.geteuid() != 0:
+        cmd = ["/usr/bin/sudo", *cmd]
     return subprocess.Popen(
         cmd,
         stdin=subprocess.PIPE,


### PR DESCRIPTION
## Summary
This PR removes a redundant `sudo` wrapper from the `powermetrics` subprocess execution. Since the parent Python process (`mxtop`) is already running with root/sudo privileges, the inner `sudo` is unnecessary and introduces process group isolation that leads to orphaned background processes. 

To illustrate the impact:
- Run `sudo mxtop`
- Quit in an unintended way (Cmd + Q, or sending sigkill through `kill -9 <PID>`)
- Search for 'powermetrics', it is left orphaned.

---

## The Problem
When `powermetrics` is invoked with `sudo` inside a Python script that already has root privileges, it triggers `sudo`'s safety mechanisms (allocating a new pseudo-terminal). This breaks the process tree by placing `powermetrics` and its helper into distinct process groups. 

### Before (Process Group Isolation)
Because `sudo (43163)` and `powermetrics (43164)` run in their own process groups, signals (like `SIGKILL` or terminal hangups) sent to Python's process group cannot propagate to them. When Python is terminated, `powermetrics` is left running as an orphan.

```text
[Terminal / Parent]
  └── python3.14 (PID: 43126, PGID: 43126)
        └── sudo (PID: 43162, PGID: 43126)            <-- Main Sudo Parent
              └── sudo (PID: 43163, PGID: 43163)      <-- Monitor Sudo (New PGID)
                    └── powermetrics (PID: 43164, PGID: 43164) (New PGID)
```

---

## The Solution
By launching `powermetrics` directly without the redundant `sudo` wrapper, we maintain root execution (inherited from the parent Python process) while keeping the child process in the same process group.

### After (Inherited Process Group)
Since `powermetrics` now shares Python's process group, termination signals (such as a forced quit or process group `SIGKILL`) cleanly propagate down to `powermetrics`, preventing orphan leaks.

```text
[Terminal / Parent]
  └── python3.14 (PID: 43126, PGID: 43126)
        └── powermetrics (PID: 43164, PGID: 43126)     <-- Shared PGID
```

---

## Changes
* Removed `"sudo"` from the `subprocess` arguments when launching `powermetrics`.
* Ensured the process inherits the existing root privileges cleanly.