### PR TITLE
fix: fall back to xterm-256color when TERM has no terminfo entry

### DIFF
--- a/mxtop/__init__.py
+++ b/mxtop/__init__.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import curses
 import os
 
-_FALLBACK_TERM = "xterm-256color"
+from .constants import FALLBACK_TERM
 
 
-def ensure_known_term(fallback: str = _FALLBACK_TERM) -> str | None:
+def ensure_known_term(fallback: str = FALLBACK_TERM) -> str | None:
     """Fall back to a known TERM when the current one has no terminfo entry.
 
     Terminals such as Ghostty ship a terminfo name (``xterm-ghostty``) that is

--- a/mxtop/__init__.py
+++ b/mxtop/__init__.py
@@ -1,1 +1,29 @@
 """mxtop — Performance monitoring CLI tool for Apple Silicon."""
+
+from __future__ import annotations
+
+import curses
+import os
+
+_FALLBACK_TERM = "xterm-256color"
+
+
+def ensure_known_term(fallback: str = _FALLBACK_TERM) -> str | None:
+    """Fall back to a known TERM when the current one has no terminfo entry.
+
+    Terminals such as Ghostty ship a terminfo name (``xterm-ghostty``) that is
+    absent from the system database, which makes blessed — and therefore the
+    whole UI — degrade to a warning and no styling. Must run before blessed is
+    imported. Returns the TERM actually in effect.
+    """
+    term = os.environ.get("TERM")
+    if not term:
+        return term
+    try:
+        curses.setupterm(term, 1)
+    except Exception:  # noqa: BLE001 — curses.error, or a closed fd
+        os.environ["TERM"] = term = fallback
+    return term
+
+
+ensure_known_term()

--- a/mxtop/constants.py
+++ b/mxtop/constants.py
@@ -1,0 +1,4 @@
+"""Tunable constants shared across mxtop."""
+
+FALLBACK_TERM = "xterm-256color"
+"""TERM used when the current one has no entry in the terminfo database."""

--- a/tests/test_term.py
+++ b/tests/test_term.py
@@ -1,0 +1,24 @@
+"""TERM fallback for terminals without a terminfo entry (e.g. Ghostty)."""
+
+import os
+import subprocess
+import sys
+
+CODE = "import mxtop, os; print(os.environ['TERM'])"
+
+
+def _term_after_import(term: str) -> str:
+    env = {**os.environ, "TERM": term}
+    out = subprocess.run(
+        [sys.executable, "-c", CODE], env=env, capture_output=True, text=True, check=True,
+    )
+    return out.stdout.strip()
+
+
+def test_unknown_term_falls_back():
+    assert _term_after_import("xterm-nosuchterm-xyz") == "xterm-256color"
+
+
+def test_known_term_is_kept():
+    assert _term_after_import("xterm-256color") == "xterm-256color"
+    assert _term_after_import("vt100") == "vt100"


### PR DESCRIPTION
## What

`TERM` values with no entry in the system terminfo database (Ghostty's `xterm-ghostty`) now fall back to `xterm-256color` at package import, before `blessed` is loaded.

## Why

Fixes #5. Under Ghostty, `blessed` fails `setupterm(kind='xterm-ghostty')`, prints

```
UserWarning: Failed to setupterm(kind='xterm-ghostty'): setupterm: could not find terminfo database
```

and renders the dashboard unstyled/broken. Same root cause as asitop#82. Reproduced on this machine — `xterm-ghostty` is absent from `/usr/share/terminfo`:

```
$ python -c "import curses,sys; curses.setupterm('xterm-ghostty', sys.stdout.fileno())"
_curses.error: setupterm: could not find terminal
```

Today the only workarounds are `TERM=xterm-256color sudo mxtop` or editing `~/.config/ghostty/config`.

## How

`mxtop/__init__.py` probes the current `TERM` with stdlib `curses.setupterm`; on failure it rewrites `os.environ["TERM"]`. It lives in `__init__.py` because it must run before `mxtop.ui` imports `dashing` → `blessed`, which reads `TERM` when the `Terminal` is built.

Rejected: passing `kind=` to `blessed.Terminal` — `dashing` builds the `Terminal` itself, so there is no seam. Rejected: shipping a terminfo entry — that is Ghostty's job, and it would not cover the next terminal with the same problem.

## Comparison

| TERM | before | after |
|---|---|---|
| `xterm-ghostty` (terminfo absent) | warning, unstyled/broken UI | falls back to `xterm-256color`, UI renders |
| `xterm-256color` | works | unchanged |
| `vt100` | works | unchanged (kept, not rewritten) |
| unset | works | unchanged (no probe) |

## Validation

```
uv run pytest tests/ -q          # 66 passed
```

Two tests added in `tests/test_term.py`, each importing `mxtop` in a subprocess with a given `TERM` and asserting the resulting value: unknown → `xterm-256color`, known (`xterm-256color`, `vt100`) → kept.

Mutation-checked: reverting `__init__.py` to its previous content (verified the `setupterm` call was gone, `grep -c` → 0) makes `test_unknown_term_falls_back` fail; restoring it makes it pass.
