### PR TITLE
feat: show disk I/O throughput alongside network

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ A Python-based `nvtop`-inspired command line tool for Apple Silicon (aka M1) Mac
 * Memory info:
   * RAM and swap, size and usage
   * (Apple removed memory bandwidth from `powermetrics`)
+* I/O info:
+  * Network throughput (up/down)
+  * Disk throughput (read/write)
 * Top processes:
   * Heaviest processes by CPU, with their resident memory
 * Power info:

--- a/mxtop/constants.py
+++ b/mxtop/constants.py
@@ -2,3 +2,6 @@
 
 FALLBACK_TERM = "xterm-256color"
 """TERM used when the current one has no entry in the terminfo database."""
+
+DISK_GAUGE_FULL_SCALE = 1024 ** 3
+"""Throughput, in bytes/s, at which the disk I/O gauge reads full (1 GB/s)."""

--- a/mxtop/mxtop.py
+++ b/mxtop/mxtop.py
@@ -30,6 +30,7 @@ from .updater import (
     update_power_widgets,
     update_network_widget,
     update_top_widget,
+    update_disk_widget,
 )
 
 
@@ -184,6 +185,9 @@ def main():
 
                 # --- Network I/O ---
                 update_network_widget(w, bg_collector.network, interval=args.interval)
+
+                # --- Disk I/O ---
+                update_disk_widget(w, bg_collector.disk)
 
                 # --- Top processes ---
                 update_top_widget(w, bg_collector.top)

--- a/mxtop/system_info.py
+++ b/mxtop/system_info.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import subprocess
 import threading
+import time
 from typing import Any
 
 import psutil
@@ -309,6 +310,25 @@ def get_top_processes(count: int = 5) -> list[dict[str, Any]]:
 
 
 # ---------------------------------------------------------------------------
+# Disk throughput (bytes read/written since boot)
+# ---------------------------------------------------------------------------
+
+def get_disk_throughput() -> dict[str, float]:
+    """Return cumulative disk I/O counters plus the sampling timestamp.
+
+    Keys: ``read_bytes``, ``write_bytes``, ``t`` (``time.monotonic()``).
+    ``read_bytes``/``write_bytes`` are 0 when the platform exposes no
+    counters (psutil returns ``None`` on some sandboxed setups).
+    """
+    counters = psutil.disk_io_counters()
+    return {
+        "read_bytes": float(counters.read_bytes) if counters else 0.0,
+        "write_bytes": float(counters.write_bytes) if counters else 0.0,
+        "t": time.monotonic(),
+    }
+
+
+# ---------------------------------------------------------------------------
 # Background metrics collector
 # ---------------------------------------------------------------------------
 
@@ -344,6 +364,7 @@ class BackgroundMetricsCollector:
         self._top: list[dict[str, Any]] = []
         if top_count:
             get_top_processes(top_count)  # prime psutil's per-process CPU state
+        self._disk: dict[str, float] = get_disk_throughput()
 
         self._lock = threading.Lock()
         self._thread: threading.Thread | None = None
@@ -370,6 +391,11 @@ class BackgroundMetricsCollector:
         with self._lock:
             return list(self._top)
 
+    @property
+    def disk(self) -> dict[str, float]:
+        with self._lock:
+            return dict(self._disk)
+
     # -- lifecycle --
 
     def start(self, stop_event: threading.Event) -> None:
@@ -388,11 +414,13 @@ class BackgroundMetricsCollector:
                 power = get_power_metrics()
                 network = get_network_throughput()
                 top = get_top_processes(self.top_count) if self.top_count else []
+                disk = get_disk_throughput()
                 with self._lock:
                     self._wifi = wifi
                     self._power = power
                     self._network = network
                     self._top = top
+                    self._disk = disk
                 logger.debug("Background metrics refreshed")
             except Exception:
                 logger.opt(exception=True).warning("Background metrics collection failed")

--- a/mxtop/ui.py
+++ b/mxtop/ui.py
@@ -113,8 +113,11 @@ def build_ui(args: Any, soc_info: dict[str, Any]) -> tuple[Any, dict[str, Any]]:
     # ---- Network throughput panel ----------------------------------------
     net_gauge = HGauge(title="Network", val=0, color=color)
 
-    # ---- Network throughput wrapped panel ---------------------------------
-    net_panel = VSplit(net_gauge, border_color=color, title="Network I/O")
+    # ---- Disk throughput panel -------------------------------------------
+    disk_gauge = HGauge(title="Disk", val=0, color=color)
+
+    # ---- I/O wrapped panel ------------------------------------------------
+    net_panel = VSplit(net_gauge, disk_gauge, border_color=color, title="I/O")
 
     # ---- Top processes panel ---------------------------------------------
     top_text = None
@@ -159,6 +162,7 @@ def build_ui(args: Any, soc_info: dict[str, Any]) -> tuple[Any, dict[str, Any]]:
         "battery_gauge":     battery_gauge,
         "charger_gauge":     charger_gauge,
         "net_gauge":         net_gauge,
+        "disk_gauge":        disk_gauge,
         "top_text":          top_text,
     }
     return ui, widgets

--- a/mxtop/updater.py
+++ b/mxtop/updater.py
@@ -8,6 +8,7 @@ from dashing import HChart
 
 from loguru import logger
 
+from .constants import DISK_GAUGE_FULL_SCALE
 from .utils import get_ram_metrics_dict
 
 
@@ -288,8 +289,6 @@ def update_top_widget(w: dict[str, Any], top: list[dict[str, Any]]) -> None:
 
 _prev_disk: dict[str, float] | None = None
 
-_DISK_GAUGE_FULL_SCALE = 1024 ** 3  # 1 GB/s reads as a full gauge
-
 
 def update_disk_widget(w: dict[str, Any], disk: dict[str, float]) -> None:
     """Refresh the disk I/O gauge with per-second throughput.
@@ -317,6 +316,6 @@ def update_disk_widget(w: dict[str, Any], disk: dict[str, float]) -> None:
         f"  W {_format_bytes(int(write_rate))}/s"
     )
     w["disk_gauge"].value = max(
-        0, min(100, int((read_rate + write_rate) / _DISK_GAUGE_FULL_SCALE * 100))
+        0, min(100, int((read_rate + write_rate) / DISK_GAUGE_FULL_SCALE * 100))
     )
     _prev_disk = disk

--- a/mxtop/updater.py
+++ b/mxtop/updater.py
@@ -280,3 +280,43 @@ def update_top_widget(w: dict[str, Any], top: list[dict[str, Any]]) -> None:
         f"{row['name'][:18]}"
         for row in top
     )
+
+
+# ---------------------------------------------------------------------------
+# Disk throughput widget update
+# ---------------------------------------------------------------------------
+
+_prev_disk: dict[str, float] | None = None
+
+_DISK_GAUGE_FULL_SCALE = 1024 ** 3  # 1 GB/s reads as a full gauge
+
+
+def update_disk_widget(w: dict[str, Any], disk: dict[str, float]) -> None:
+    """Refresh the disk I/O gauge with per-second throughput.
+
+    *disk* is a pre-fetched dict from the background collector; rates are
+    derived from its own ``t`` timestamp, so they stay correct whatever the
+    collector's refresh interval is.
+    """
+    global _prev_disk
+
+    prev, _prev_disk = _prev_disk, disk
+    if prev is None:
+        w["disk_gauge"].title = "Disk: measuring…"
+        w["disk_gauge"].value = 0
+        return
+
+    elapsed = disk["t"] - prev["t"]
+    if elapsed <= 0:  # same sample seen twice — keep the previous reading
+        return
+
+    read_rate = (disk["read_bytes"] - prev["read_bytes"]) / elapsed
+    write_rate = (disk["write_bytes"] - prev["write_bytes"]) / elapsed
+    w["disk_gauge"].title = (
+        f"Disk: R {_format_bytes(int(read_rate))}/s"
+        f"  W {_format_bytes(int(write_rate))}/s"
+    )
+    w["disk_gauge"].value = max(
+        0, min(100, int((read_rate + write_rate) / _DISK_GAUGE_FULL_SCALE * 100))
+    )
+    _prev_disk = disk

--- a/tests/test_disk.py
+++ b/tests/test_disk.py
@@ -1,0 +1,62 @@
+"""Disk I/O collection and widget update."""
+
+from types import SimpleNamespace
+
+from mxtop import updater
+from mxtop.system_info import get_disk_throughput
+
+
+def _widgets():
+    return {"disk_gauge": SimpleNamespace(title="", value=0)}
+
+
+def setup_function():
+    updater._prev_disk = None
+
+
+def test_get_disk_throughput_keys():
+    d = get_disk_throughput()
+    assert set(d) == {"read_bytes", "write_bytes", "t"}
+    assert d["read_bytes"] >= 0 and d["write_bytes"] >= 0
+
+
+def test_first_sample_only_primes():
+    w = _widgets()
+    updater.update_disk_widget(w, {"read_bytes": 0.0, "write_bytes": 0.0, "t": 100.0})
+    assert "measuring" in w["disk_gauge"].title
+
+
+def test_rate_uses_sample_timestamps():
+    w = _widgets()
+    updater.update_disk_widget(w, {"read_bytes": 0.0, "write_bytes": 0.0, "t": 100.0})
+    # 10 MB read + 5 MB written over 5 s -> 2.0 MB/s read, 1.0 MB/s written
+    updater.update_disk_widget(
+        w,
+        {
+            "read_bytes": 10 * 1024**2,
+            "write_bytes": 5 * 1024**2,
+            "t": 105.0,
+        },
+    )
+    assert "R 2.0 MB/s" in w["disk_gauge"].title
+    assert "W 1.0 MB/s" in w["disk_gauge"].title
+    # 3 MB/s out of a 1 GB/s full-scale gauge rounds to 0%
+    assert w["disk_gauge"].value == 0
+
+
+def test_gauge_saturates_and_clamps():
+    w = _widgets()
+    updater.update_disk_widget(w, {"read_bytes": 0.0, "write_bytes": 0.0, "t": 0.0})
+    updater.update_disk_widget(
+        w, {"read_bytes": 4 * 1024**3, "write_bytes": 0.0, "t": 1.0},
+    )
+    assert w["disk_gauge"].value == 100
+
+
+def test_repeated_sample_keeps_previous_reading():
+    w = _widgets()
+    updater.update_disk_widget(w, {"read_bytes": 0.0, "write_bytes": 0.0, "t": 0.0})
+    updater.update_disk_widget(w, {"read_bytes": 1024.0, "write_bytes": 0.0, "t": 1.0})
+    title = w["disk_gauge"].title
+    updater.update_disk_widget(w, {"read_bytes": 1024.0, "write_bytes": 0.0, "t": 1.0})
+    assert w["disk_gauge"].title == title


### PR DESCRIPTION
## What

A **Disk** gauge next to the existing Network gauge — read and write throughput per second — fed by `psutil.disk_io_counters()` from the background collector. The panel is renamed `Network I/O` → `I/O`.

## Why

mxtop already reports CPU, GPU, ANE, RAM, power, WiFi and network, but disk was the one obvious I/O channel missing — and it is often what an "everything looks idle but the machine is slow" session turns out to be. `psutil` is already a dependency, so no new install.

## How

- `system_info.get_disk_throughput()` returns the cumulative counters **plus** a `time.monotonic()` timestamp, and yields zeros when psutil returns no counters.
- `BackgroundMetricsCollector` collects it in the same 5 s pass as WiFi/power/network and exposes `.disk`.
- `updater.update_disk_widget()` derives rates from the **sample timestamps**, not from `args.interval`.

That last point is deliberate: the collector refreshes every 5 s while `--interval` defaults to 1 s, so dividing by `args.interval` (as `update_network_widget` does today) overstates rates by the ratio of the two. Deriving from the sample's own clock is correct whatever either interval is. I have left the network widget alone here to keep this PR to one thing — happy to send the network fix as a separate PR.

Gauge full scale is 1 GB/s; the title always shows the absolute numbers, so the bar is only an at-a-glance hint.

## Comparison

| | before | after |
|---|---|---|
| Disk read/write rate | not shown | `Disk: R 300.0 MB/s  W 120.0 MB/s` |
| Panel | `Network I/O` (1 gauge) | `I/O` (2 gauges) |
| New dependencies | — | none (`psutil` already required) |
| Extra cost per refresh | — | one `psutil.disk_io_counters()` in the existing background pass |

## Validation

```
uv run pytest tests/ -q          # 67 passed
```

`tests/test_disk.py` covers: the collector's key set, the first sample only priming (no bogus rate), exact rate arithmetic from timestamps (10 MB / 5 s → `R 2.0 MB/s`), gauge clamping at 100%, and a repeated sample leaving the reading untouched.

Rendering smoke-checked through the real `build_ui`:

```
Disk: R 300.0 MB/s  W 120.0 MB/s | value: 41
```

Mutation-checked: replacing `elapsed = disk["t"] - prev["t"]` with a constant `1.0` (confirmed applied — the mutated line was printed before the run) fails `test_rate_uses_sample_timestamps` and `test_repeated_sample_keeps_previous_reading`; restoring it passes.
