### PR TITLE
feat: add a top-processes panel (--top N)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ A Python-based `nvtop`-inspired command line tool for Apple Silicon (aka M1) Mac
 * Memory info:
   * RAM and swap, size and usage
   * (Apple removed memory bandwidth from `powermetrics`)
+* Top processes:
+  * Heaviest processes by CPU, with their resident memory
 * Power info:
   * CPU power, GPU power (Apple removed package power from `powermetrics`)
   * Chart for CPU/GPU power
@@ -54,7 +56,7 @@ mxtop
 
 # all options
 mxtop [-h] [--interval INTERVAL] [--color COLOR] [--avg AVG]
-            [--show_cores SHOW_CORES] [--max_count MAX_COUNT]
+            [--show_cores SHOW_CORES] [--max_count MAX_COUNT] [--top N]
 
 options:
   -h, --help            show this help message and exit
@@ -63,6 +65,8 @@ options:
   --avg AVG             Interval for averaged values (seconds)
   --show_cores          Show individual core utilization
   --max_count MAX_COUNT Max samples before restarting powermetrics (0 = unlimited)
+  --top N               Number of top CPU processes to display (0 hides the
+                        panel, default 5)
 ```
 
 ## How it works

--- a/mxtop/mxtop.py
+++ b/mxtop/mxtop.py
@@ -29,6 +29,7 @@ from .updater import (
     update_wifi_widget,
     update_power_widgets,
     update_network_widget,
+    update_top_widget,
 )
 
 
@@ -59,6 +60,10 @@ def main():
     parser.add_argument(
         "--max_count", type=int, default=0,
         help="Max sample count before restarting powermetrics (0 = unlimited)",
+    )
+    parser.add_argument(
+        "--top", type=int, default=5,
+        help="Number of top CPU processes to display (0 = hide the panel)",
     )
     parser.add_argument(
         "--log-level", type=str, default="WARNING",
@@ -124,7 +129,7 @@ def main():
     kb_thread.start()
 
     # Start background metrics collector (WiFi, battery, network — slow calls)
-    bg_collector = BackgroundMetricsCollector(interval=5.0)
+    bg_collector = BackgroundMetricsCollector(interval=5.0, top_count=args.top)
     bg_collector.start(stop_event)
 
     clear_console()
@@ -179,6 +184,9 @@ def main():
 
                 # --- Network I/O ---
                 update_network_widget(w, bg_collector.network, interval=args.interval)
+
+                # --- Top processes ---
+                update_top_widget(w, bg_collector.top)
 
                 ui.display()
 

--- a/mxtop/system_info.py
+++ b/mxtop/system_info.py
@@ -278,6 +278,37 @@ def get_network_throughput() -> dict[str, int]:
 
 
 # ---------------------------------------------------------------------------
+# Top processes
+# ---------------------------------------------------------------------------
+
+def get_top_processes(count: int = 5) -> list[dict[str, Any]]:
+    """Return the *count* heaviest processes by CPU, then by memory.
+
+    Each entry has ``pid``, ``name``, ``cpu_percent`` and ``rss``.
+
+    ``cpu_percent`` is measured between successive calls, so the very first
+    call after startup reports 0.0 for every process — psutil keeps the
+    per-process state behind ``process_iter``, and the ranking becomes
+    meaningful from the second call on.
+    """
+    rows: list[dict[str, Any]] = []
+    for proc in psutil.process_iter(["pid", "name", "cpu_percent", "memory_info"]):
+        try:
+            info = proc.info
+            mem = info["memory_info"]
+            rows.append({
+                "pid": info["pid"],
+                "name": info["name"] or "?",
+                "cpu_percent": info["cpu_percent"] or 0.0,
+                "rss": mem.rss if mem else 0,
+            })
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+    rows.sort(key=lambda r: (r["cpu_percent"], r["rss"]), reverse=True)
+    return rows[:count]
+
+
+# ---------------------------------------------------------------------------
 # Background metrics collector
 # ---------------------------------------------------------------------------
 
@@ -295,8 +326,9 @@ class BackgroundMetricsCollector:
         net   = collector.network
     """
 
-    def __init__(self, interval: float = 5.0) -> None:
+    def __init__(self, interval: float = 5.0, top_count: int = 5) -> None:
         self.interval = interval
+        self.top_count = top_count
 
         # Latest snapshots (read by main thread, written by bg thread)
         self._wifi: dict[str, Any] = {
@@ -309,6 +341,9 @@ class BackgroundMetricsCollector:
             "wattage": None, "adapter_name": None, "cable_connected": False,
         }
         self._network: dict[str, int] = {"bytes_sent": 0, "bytes_recv": 0}
+        self._top: list[dict[str, Any]] = []
+        if top_count:
+            get_top_processes(top_count)  # prime psutil's per-process CPU state
 
         self._lock = threading.Lock()
         self._thread: threading.Thread | None = None
@@ -330,6 +365,11 @@ class BackgroundMetricsCollector:
         with self._lock:
             return dict(self._network)
 
+    @property
+    def top(self) -> list[dict[str, Any]]:
+        with self._lock:
+            return list(self._top)
+
     # -- lifecycle --
 
     def start(self, stop_event: threading.Event) -> None:
@@ -347,10 +387,12 @@ class BackgroundMetricsCollector:
                 wifi = get_wifi_metrics()
                 power = get_power_metrics()
                 network = get_network_throughput()
+                top = get_top_processes(self.top_count) if self.top_count else []
                 with self._lock:
                     self._wifi = wifi
                     self._power = power
                     self._network = network
+                    self._top = top
                 logger.debug("Background metrics refreshed")
             except Exception:
                 logger.opt(exception=True).warning("Background metrics collection failed")

--- a/mxtop/ui.py
+++ b/mxtop/ui.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from dashing import VSplit, HSplit, HGauge, HChart, VGauge
+from dashing import VSplit, HSplit, HGauge, HChart, VGauge, Text
 
 from loguru import logger
 
@@ -116,20 +116,29 @@ def build_ui(args: Any, soc_info: dict[str, Any]) -> tuple[Any, dict[str, Any]]:
     # ---- Network throughput wrapped panel ---------------------------------
     net_panel = VSplit(net_gauge, border_color=color, title="Network I/O")
 
+    # ---- Top processes panel ---------------------------------------------
+    top_text = None
+    panels = [memory_gauges, system_info_panel, net_panel]
+    if getattr(args, "top", 0):
+        top_text = Text("sampling…", color=color)
+        panels.append(
+            VSplit(top_text, border_color=color, title=f"Top {args.top} (CPU)")
+        )
+
     # ---- Top-level layout ------------------------------------------------
     if args.show_cores:
         ui = HSplit(
             processor_split,
             VSplit(
                 memory_gauges,
-                HSplit(system_info_panel, net_panel),
+                HSplit(*panels[1:]),
                 power_charts,
             ),
         )
     else:
         ui = VSplit(
             processor_split,
-            HSplit(memory_gauges, system_info_panel, net_panel),
+            HSplit(*panels),
             power_charts,
         )
 
@@ -150,5 +159,6 @@ def build_ui(args: Any, soc_info: dict[str, Any]) -> tuple[Any, dict[str, Any]]:
         "battery_gauge":     battery_gauge,
         "charger_gauge":     charger_gauge,
         "net_gauge":         net_gauge,
+        "top_text":          top_text,
     }
     return ui, widgets

--- a/mxtop/updater.py
+++ b/mxtop/updater.py
@@ -258,3 +258,25 @@ def update_network_widget(
         w["net_gauge"].value = 0
 
     _prev_net = current
+
+
+# ---------------------------------------------------------------------------
+# Top processes widget update
+# ---------------------------------------------------------------------------
+
+def update_top_widget(w: dict[str, Any], top: list[dict[str, Any]]) -> None:
+    """Render the top-processes table.
+
+    *top* is a pre-fetched list from the background collector.
+    """
+    widget = w.get("top_text")
+    if widget is None:
+        return
+    if not top:
+        widget.text = "sampling…"
+        return
+    widget.text = "\n".join(
+        f"{row['cpu_percent']:5.1f}% {_format_bytes(row['rss']):>9}  "
+        f"{row['name'][:18]}"
+        for row in top
+    )

--- a/tests/test_top_processes.py
+++ b/tests/test_top_processes.py
@@ -1,0 +1,71 @@
+"""Top-processes collection, rendering and the --top flag."""
+
+from types import SimpleNamespace
+
+from mxtop import system_info
+from mxtop.system_info import get_top_processes
+from mxtop.ui import build_ui
+from mxtop.updater import update_top_widget
+
+SOC = {
+    "e_core_count": 4, "p_core_count": 4,
+    "gpu_core_count": 10, "name": "Apple M3",
+}
+
+
+class _FakeProc:
+    def __init__(self, pid, name, cpu, rss):
+        self.info = {
+            "pid": pid, "name": name, "cpu_percent": cpu,
+            "memory_info": SimpleNamespace(rss=rss),
+        }
+
+
+def test_get_top_processes_shape():
+    rows = get_top_processes(5)
+    assert 0 < len(rows) <= 5
+    assert set(rows[0]) == {"pid", "name", "cpu_percent", "rss"}
+
+
+def test_heaviest_cpu_first_then_memory(monkeypatch):
+    procs = [
+        _FakeProc(1, "idle", 0.0, 10),
+        _FakeProc(2, "busy", 90.0, 10),
+        _FakeProc(3, "medium", 5.0, 10),
+        _FakeProc(4, "fat-idle", 0.0, 999),
+    ]
+    monkeypatch.setattr(system_info.psutil, "process_iter", lambda attrs: procs)
+    assert [r["name"] for r in get_top_processes(4)] == [
+        "busy", "medium", "fat-idle", "idle",
+    ]
+    assert [r["name"] for r in get_top_processes(2)] == ["busy", "medium"]
+
+
+def test_render_formats_one_line_per_process():
+    w = {"top_text": SimpleNamespace(text="")}
+    update_top_widget(w, [
+        {"pid": 1, "name": "python3.13", "cpu_percent": 42.5, "rss": 3 * 1024**2},
+        {"pid": 2, "name": "a-very-long-process-name", "cpu_percent": 1.0, "rss": 512},
+    ])
+    lines = w["top_text"].text.splitlines()
+    assert len(lines) == 2
+    assert " 42.5%" in lines[0] and "3.0 MB" in lines[0] and "python3.13" in lines[0]
+    assert "a-very-long-proces" in lines[1]  # name truncated to 18 chars
+    assert "a-very-long-process-name" not in lines[1]
+
+
+def test_render_before_first_sample():
+    w = {"top_text": SimpleNamespace(text="x")}
+    update_top_widget(w, [])
+    assert "sampling" in w["top_text"].text
+
+
+def test_top_zero_hides_panel():
+    _, w = build_ui(SimpleNamespace(color=2, show_cores=False, top=0), SOC)
+    assert w["top_text"] is None
+    update_top_widget(w, [{"pid": 1, "name": "x", "cpu_percent": 1.0, "rss": 1}])
+
+
+def test_top_nonzero_creates_panel():
+    _, w = build_ui(SimpleNamespace(color=2, show_cores=False, top=5), SOC)
+    assert w["top_text"] is not None


### PR DESCRIPTION
## What

A **Top N (CPU)** panel listing the heaviest processes with their CPU share and resident memory, controlled by a new `--top N` flag (default 5, `--top 0` hides the panel).

```
 27.7%  492.9 MB  Browser Helper (Re
 22.6%  121.5 MB  iTerm2
 16.9%  120.1 MB  Browser Helper
 10.8%  360.3 MB  Music
  5.4%  350.3 MB  2.1.227
```

## Why

mxtop answers "how loaded is this machine" but not "by what". Today that means running `top` in a second pane. `psutil` is already a dependency, so the answer is a few lines away.

## How

- `system_info.get_top_processes(count)` walks `psutil.process_iter(["pid", "name", "cpu_percent", "memory_info"])`, skips `NoSuchProcess`/`AccessDenied`, and sorts by CPU with RSS as the tie-breaker (so an idle box still ranks by memory instead of showing an arbitrary five).
- Sampling happens in `BackgroundMetricsCollector` alongside WiFi/power/network — `process_iter` over ~700 processes is far too slow for the 1 s display loop. The collector primes psutil's per-process CPU state in `__init__`, since `cpu_percent` is measured between calls and the first one always returns 0.0.
- `updater.update_top_widget()` renders into a `dashing.Text` tile; names are truncated to 18 chars.
- `--top 0` leaves `top_text` as `None` and the panel out of the layout entirely; the updater no-ops.

Rejected: sampling in the main loop (blocks the UI), and a `Log` tile (append-only, so it would grow without bound).

## Comparison

| | before | after |
|---|---|---|
| "what is using my CPU" | not answered — `top` in another pane | in-panel, refreshed every 5 s |
| Layout with `--top 0` | — | byte-identical to before |
| New dependencies | — | none (`psutil` already required) |
| Main-loop cost | — | none; sampling stays in the background thread |

## Validation

```
uv run pytest tests/ -q          # 68 passed
```

`tests/test_top_processes.py` covers the returned shape against the live system, ordering against a monkeypatched `process_iter` (CPU first, RSS as tie-break, `count` respected), the rendered line format including name truncation, the pre-first-sample placeholder, and both `--top 0` (no panel, updater no-ops) and `--top 5` (panel present) through the real `build_ui`.

Rendering smoke-checked through `build_ui` + `ui.display()` — output above is the real panel.

Mutation-checked: dropping `reverse=True` from the sort (confirmed applied — the mutated line was printed before the run) fails `test_heaviest_cpu_first_then_memory`; restoring it passes. An earlier version of that test used live processes and survived the mutation, because the bottom five all sit at 0.0% and compare equal — hence the monkeypatched fixture.
