### PR TITLE
feat: export samples to CSV or JSON Lines (--export PATH)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ mxtop
 # all options
 mxtop [-h] [--interval INTERVAL] [--color COLOR] [--avg AVG]
             [--show_cores SHOW_CORES] [--max_count MAX_COUNT] [--top N]
+            [--export PATH]
 
 options:
   -h, --help            show this help message and exit
@@ -67,6 +68,11 @@ options:
   --max_count MAX_COUNT Max samples before restarting powermetrics (0 = unlimited)
   --top N               Number of top CPU processes to display (0 hides the
                         panel, default 5)
+  --export PATH         Append every sample to PATH. `.csv` writes a header row
+                        plus one row per sample; `.json`, `.jsonl` and `.ndjson`
+                        write JSON Lines (one object per line). Rows are flushed
+                        as they are written, so the file is readable while mxtop
+                        runs and stays complete if the run is interrupted.
 ```
 
 ## How it works

--- a/mxtop/export.py
+++ b/mxtop/export.py
@@ -1,0 +1,84 @@
+"""Sample export — write each reading to a CSV or JSON Lines file."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Any, TextIO
+
+from loguru import logger
+
+_FORMATS = {".csv": "csv", ".jsonl": "jsonl", ".json": "jsonl", ".ndjson": "jsonl"}
+
+
+def sample_row(
+    timestamp: Any,
+    cpu_metrics: dict[str, Any],
+    gpu_metrics: dict[str, Any],
+    ram: dict[str, Any],
+    thermal_pressure: str,
+) -> dict[str, Any]:
+    """Flatten one reading into the exported record."""
+    return {
+        "timestamp": timestamp.isoformat() if hasattr(timestamp, "isoformat") else str(timestamp),
+        "e_cluster_active_pct": cpu_metrics["E-Cluster_active"],
+        "e_cluster_freq_mhz": cpu_metrics["E-Cluster_freq_Mhz"],
+        "p_cluster_active_pct": cpu_metrics["P-Cluster_active"],
+        "p_cluster_freq_mhz": cpu_metrics["P-Cluster_freq_Mhz"],
+        "gpu_active_pct": gpu_metrics["active"],
+        "gpu_freq_mhz": gpu_metrics["freq_MHz"],
+        "package_w": cpu_metrics["package_W"],
+        "cpu_w": cpu_metrics["cpu_W"],
+        "gpu_w": cpu_metrics["gpu_W"],
+        "ane_w": cpu_metrics["ane_W"],
+        "ram_used_gb": ram["used_GB"],
+        "ram_total_gb": ram["total_GB"],
+        "swap_used_gb": ram["swap_used_GB"],
+        "thermal_pressure": thermal_pressure,
+    }
+
+
+class Exporter:
+    """Append one record per sample to *path*.
+
+    The format follows the extension: ``.csv`` writes CSV with a header row,
+    ``.json`` / ``.jsonl`` / ``.ndjson`` write JSON Lines — one object per
+    line, so the file stays valid and readable while mxtop is still running.
+
+    Rows are flushed as they are written; a run killed with ``q`` or Ctrl-C
+    still leaves a complete file.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        fmt = _FORMATS.get(self.path.suffix.lower())
+        if fmt is None:
+            raise ValueError(
+                f"unsupported export extension {self.path.suffix!r} — "
+                f"use one of {', '.join(sorted(_FORMATS))}"
+            )
+        self.format = fmt
+        self._fh: TextIO = self.path.open("w", newline="", encoding="utf-8")
+        self._writer: csv.DictWriter | None = None
+        logger.info("Exporting samples to {} ({})", self.path, self.format)
+
+    def write(self, row: dict[str, Any]) -> None:
+        if self.format == "csv":
+            if self._writer is None:
+                self._writer = csv.DictWriter(self._fh, fieldnames=list(row))
+                self._writer.writeheader()
+            self._writer.writerow(row)
+        else:
+            self._fh.write(json.dumps(row) + "\n")
+        self._fh.flush()
+
+    def close(self) -> None:
+        if not self._fh.closed:
+            self._fh.close()
+
+    def __enter__(self) -> Exporter:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()

--- a/mxtop/mxtop.py
+++ b/mxtop/mxtop.py
@@ -11,6 +11,7 @@ from collections import deque
 from loguru import logger
 
 from .utils import (
+    get_ram_metrics_dict,
     get_soc_info,
     run_powermetrics_process,
     parse_powermetrics,
@@ -20,6 +21,7 @@ from .utils import (
 from .keyboard import keyboard_listener
 from .ui import build_ui
 from .system_info import BackgroundMetricsCollector
+from .export import Exporter, sample_row
 from .updater import (
     _MAX_CHART_POINTS,
     _cap_chart,
@@ -66,6 +68,10 @@ def main():
         help="Number of top CPU processes to display (0 = hide the panel)",
     )
     parser.add_argument(
+        "--export", type=str, default=None, metavar="PATH",
+        help="Append every sample to PATH (.csv, or .json/.jsonl for JSON Lines)",
+    )
+    parser.add_argument(
         "--log-level", type=str, default="WARNING",
         help="Set loguru log level (DEBUG, INFO, WARNING, ERROR)",
     )
@@ -74,6 +80,8 @@ def main():
     # Configure loguru
     logger.remove()  # remove default stderr handler
     logger.add(sys.stderr, level=args.log_level.upper())
+
+    exporter = Exporter(args.export) if args.export else None
 
     print("\nmxtop - Performance monitoring CLI tool for Apple Silicon")
     print("Press  q  or  ESC  to quit.")
@@ -188,6 +196,12 @@ def main():
                 # --- Top processes ---
                 update_top_widget(w, bg_collector.top)
 
+                if exporter is not None:
+                    exporter.write(sample_row(
+                        timestamp, cpu_metrics, gpu_metrics,
+                        get_ram_metrics_dict(), thermal_pressure,
+                    ))
+
                 ui.display()
 
             time.sleep(args.interval)
@@ -199,6 +213,8 @@ def main():
             powermetrics_process.wait(timeout=3)
         except Exception:
             powermetrics_process.kill()
+        if exporter is not None:
+            exporter.close()
         cleanup_tmp_files()
         print("\033[?25h")  # restore cursor
         print("\nStopped.")

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,64 @@
+"""Sample export to CSV / JSON Lines."""
+
+import csv
+import json
+from datetime import datetime
+
+import pytest
+
+from mxtop.export import Exporter, sample_row
+
+CPU = {
+    "E-Cluster_active": 12, "E-Cluster_freq_Mhz": 1200,
+    "P-Cluster_active": 40, "P-Cluster_freq_Mhz": 3200,
+    "package_W": 8.5, "cpu_W": 5.0, "gpu_W": 3.0, "ane_W": 0.5,
+}
+GPU = {"active": 30, "freq_MHz": 900}
+RAM = {"used_GB": 12.3, "total_GB": 16.0, "swap_used_GB": 0.5}
+
+
+def test_sample_row_flattens_a_reading():
+    row = sample_row(datetime(2026, 1, 2, 3, 4, 5), CPU, GPU, RAM, "Nominal")
+    assert row["timestamp"] == "2026-01-02T03:04:05"
+    assert row["p_cluster_active_pct"] == 40
+    assert row["gpu_freq_mhz"] == 900
+    assert row["cpu_w"] == 5.0
+    assert row["ram_used_gb"] == 12.3
+    assert row["thermal_pressure"] == "Nominal"
+
+
+def test_csv_has_a_header_and_one_row_per_sample(tmp_path):
+    path = tmp_path / "out.csv"
+    with Exporter(path) as exp:
+        exp.write(sample_row("t0", CPU, GPU, RAM, "Nominal"))
+        exp.write(sample_row("t1", CPU, GPU, RAM, "Heavy"))
+    rows = list(csv.DictReader(path.read_text().splitlines()))
+    assert [r["timestamp"] for r in rows] == ["t0", "t1"]
+    assert rows[1]["thermal_pressure"] == "Heavy"
+    assert rows[0]["package_w"] == "8.5"
+
+
+@pytest.mark.parametrize("suffix", [".json", ".jsonl", ".ndjson"])
+def test_json_extensions_write_json_lines(tmp_path, suffix):
+    path = tmp_path / f"out{suffix}"
+    with Exporter(path) as exp:
+        exp.write(sample_row("t0", CPU, GPU, RAM, "Nominal"))
+        exp.write(sample_row("t1", CPU, GPU, RAM, "Nominal"))
+    lines = path.read_text().splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0])["timestamp"] == "t0"
+    assert json.loads(lines[1])["gpu_w"] == 3.0
+
+
+def test_rows_are_readable_before_close(tmp_path):
+    path = tmp_path / "out.csv"
+    exp = Exporter(path)
+    exp.write(sample_row("t0", CPU, GPU, RAM, "Nominal"))
+    assert len(path.read_text().splitlines()) == 2  # header + row, already flushed
+    exp.close()
+
+
+def test_unknown_extension_is_rejected(tmp_path):
+    with pytest.raises(ValueError, match="unsupported export extension"):
+        Exporter(tmp_path / "out.txt")
+    assert not (tmp_path / "out.txt").exists()


### PR DESCRIPTION
## What

`--export PATH` appends one record per `powermetrics` sample to a file, alongside the live display. Format follows the extension: `.csv` → header + rows, `.json` / `.jsonl` / `.ndjson` → JSON Lines.

```
sudo mxtop --export run.csv
sudo mxtop --export run.jsonl --interval 5
```

Each record carries the timestamp, E/P cluster utilisation and frequency, GPU utilisation and frequency, package/CPU/GPU/ANE power, RAM/swap usage and thermal pressure.

## Why

The dashboard is live-only: today, answering "was the GPU pinned during that build" or "how much did power drop after the fix" means watching the bars and remembering. A file makes a run comparable to another run, plottable, and attachable to a bug report.

## How

`mxtop/export.py` holds `sample_row()` (flattens one reading into a flat record) and `Exporter` (opens the file, picks the writer from the extension, writes and flushes). The main loop writes a row right before `ui.display()`; `finally` closes the file.

Design points:

- **JSON Lines, not a JSON array.** A run is open-ended — an array can only be closed at exit, so a `kill -9` would leave an unparseable file, and nothing could read it mid-run. One object per line stays valid at every instant. `.json` is accepted and documented as JSON Lines rather than rejected, since that is what people type.
- **Flush per row**, so `tail -f` works and stopping with `q`/Ctrl-C loses nothing. One sample per second makes the cost irrelevant.
- **Extension validated before `powermetrics` starts**, so a typo fails in a tenth of a second instead of after the sudo prompt and the UI takeover.

Rejected: a `--export-format` flag (the extension already says it), and buffering rows to write at exit (loses the run on any hard stop).

## Comparison

| | before | after |
|---|---|---|
| Post-run analysis | none — live display only | CSV or JSON Lines per sample |
| File usable while running | — | yes (flushed per row; `tail -f`) |
| File usable after `kill -9` | — | yes (JSON Lines / CSV, no closing token) |
| Bad path/extension | — | `ValueError` before `powermetrics` is spawned |
| New dependencies | — | none (`csv`, `json` are stdlib) |
| Cost when `--export` is unset | — | none; `exporter is None`, no extra work in the loop |

## Validation

```
uv run pytest tests/ -q          # 69 passed
```

`tests/test_export.py` covers the flattening (including `datetime` → ISO), the CSV header + one row per sample, JSON Lines for all three JSON extensions, rows readable before `close()`, and an unsupported extension raising without creating the file.

CLI wiring checked end to end:

```
$ mxtop --export /tmp/nope.txt
ValueError: unsupported export extension '.txt' — use one of .csv, .json, .jsonl, .ndjson
$ mxtop --help
  --export PATH   Append every sample to PATH (.csv, or .json/.jsonl for JSON Lines)
```

Mutation-checked: removing the per-row `flush()` (confirmed applied — the mutated line was printed before the run) fails `test_rows_are_readable_before_close`; restoring it passes.
