### PR TITLE
fix: keep working when the powermetrics file is not writable

### DIFF
--- a/mxtop/utils.py
+++ b/mxtop/utils.py
@@ -61,15 +61,26 @@ def parse_powermetrics(
     or *None* if no valid data is available yet.
 
     Only the tail of the file is read to avoid unbounded memory growth
-    (powermetrics keeps appending NUL-separated plists).  After a
-    successful parse the file is truncated to keep only the last valid
-    blob, preventing disk growth as well.
+    (powermetrics keeps appending NUL-separated plists).  When the file is
+    writable it is then truncated to keep only the last valid blob,
+    preventing disk growth as well.
+
+    ``powermetrics`` always runs as root, so without ``sudo mxtop`` the file
+    belongs to root and cannot be opened for writing.  That is not fatal: the
+    file is then read read-only and left untouched.
     """
     filepath = path + timecode
+    writable = True
     try:
         fd = os.open(filepath, os.O_RDWR)
     except FileNotFoundError:
         return None
+    except PermissionError:
+        try:
+            fd = os.open(filepath, os.O_RDONLY)
+        except OSError:
+            return None
+        writable = False
 
     try:
         file_size = os.fstat(fd).st_size
@@ -88,23 +99,32 @@ def parse_powermetrics(
                 continue
             try:
                 plist = plistlib.loads(chunk)
-                # Truncate file: keep only this last good blob
-                os.ftruncate(fd, 0)
-                os.lseek(fd, 0, os.SEEK_SET)
-                os.write(fd, chunk)
-                return (
-                    parse_cpu_metrics(plist),
-                    parse_gpu_metrics(plist),
-                    parse_thermal_pressure(plist),
-                    None,
-                    plist["timestamp"],
-                )
-            except Exception:  # noqa: BLE001
+            except Exception:  # noqa: BLE001 — partial or stale blob
                 continue
+
+            if writable:
+                _keep_only_last_blob(fd, chunk)
+            return (
+                parse_cpu_metrics(plist),
+                parse_gpu_metrics(plist),
+                parse_thermal_pressure(plist),
+                None,
+                plist["timestamp"],
+            )
 
         return None
     finally:
         os.close(fd)
+
+
+def _keep_only_last_blob(fd: int, chunk: bytes) -> None:
+    """Shrink the powermetrics file to the last blob we successfully parsed."""
+    try:
+        os.ftruncate(fd, 0)
+        os.lseek(fd, 0, os.SEEK_SET)
+        os.write(fd, chunk)
+    except OSError as exc:
+        logger.debug("could not truncate powermetrics file: {}", exc)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -110,6 +110,36 @@ class TestParsePowermetrics:
         result = parse_powermetrics(path=str(f), timecode="")
         assert result is None
 
+    def test_read_only_file_is_parsed_and_left_intact(self, tmp_path):
+        """Without sudo the file belongs to root: read it, do not truncate."""
+        f = tmp_path / "pm"
+        blob = _make_plist_bytes()
+        f.write_bytes(blob + b"\x00" + blob)
+        before = f.read_bytes()
+        f.chmod(0o444)
+        try:
+            result = parse_powermetrics(path=str(f), timecode="")
+            assert result is not None
+            assert result[2] == "Nominal"
+            assert f.read_bytes() == before  # untouched
+        finally:
+            f.chmod(0o644)
+
+    def test_writable_file_is_shrunk_to_the_last_blob(self, tmp_path):
+        f = tmp_path / "pm"
+        blob = _make_plist_bytes()
+        f.write_bytes(blob + b"\x00" + blob)
+        assert parse_powermetrics(path=str(f), timecode="") is not None
+        assert f.read_bytes() == blob
+
+    def test_trailing_partial_blob_is_skipped(self, tmp_path):
+        f = tmp_path / "pm"
+        blob = _make_plist_bytes()
+        f.write_bytes(blob + b"\x00" + blob[:40])
+        result = parse_powermetrics(path=str(f), timecode="")
+        assert result is not None
+        assert result[2] == "Nominal"
+
     def test_valid_single_blob(self, tmp_path):
         f = tmp_path / "pm"
         f.write_bytes(_make_plist_bytes())


### PR DESCRIPTION
## What

`parse_powermetrics` falls back to opening the powermetrics output file read-only when it cannot open it for writing, and skips the truncation in that case.

## Why

`powermetrics` always runs as root, so `/tmp/mxtop_powermetrics<timecode>` belongs to root. Since the tail-read rewrite in 76e80aa the file is opened `O_RDWR`, which a plain user cannot do — so the non-sudo mode the README documents (`mxtop`, "it will prompt for password on start") dies on the very first reading:

```
  File "mxtop/mxtop.py", line 106, in main
    ready = parse_powermetrics(timecode=timecode)
  File "mxtop/utils.py", line 70, in parse_powermetrics
    fd = os.open(filepath, os.O_RDWR)
PermissionError: [Errno 13] Permission denied: '/tmp/mxtop_powermetrics1786444238'
```

Found while instrumenting a run for #6. Before 76e80aa the file was opened `'rb'`, so this is a regression, not a long-standing limitation.

Second, smaller bug in the same function: the `os.ftruncate`/`os.write` calls sat *inside* the `try` that guards `plistlib.loads`, so any write failure was caught by `except Exception: continue` — a good blob would be thrown away and the loop would walk backwards into older data.

## How

Try `O_RDWR`; on `PermissionError` reopen `O_RDONLY` and set `writable = False`. Truncation moves into `_keep_only_last_blob()`, called only when writable and catching its own `OSError`. The plist `except` now wraps `plistlib.loads` alone.

Read-only mode keeps the memory behaviour that matters — the read is still capped at the last 64 KiB — and only gives up the on-disk shrink, exactly as before 76e80aa.

Rejected: `chown`ing the file (needs root — the thing we do not have), and dropping the truncation for everyone (it is what keeps the temp file from reaching GBs on long runs).

## Comparison

| run | before | after |
|---|---|---|
| `sudo mxtop` | works, file truncated each sample | unchanged |
| `mxtop` (documented non-sudo mode) | `PermissionError` on the first reading | works; file read-only, not truncated |
| memory read per sample | 64 KiB cap | unchanged in both modes |
| temp file on disk, non-sudo | — | grows, as it did before 76e80aa |
| `ftruncate` fails mid-run | good blob silently discarded, older data used | blob kept, failure logged at DEBUG |

## Validation

```
uv run pytest tests/ -q          # 65 passed
```

Three tests added to `TestParsePowermetrics`: a `chmod 0444` file is parsed and left byte-identical; a writable file is still shrunk to its last blob; a trailing partial blob is skipped in favour of the last complete one.

Mutation-checked: deleting the `PermissionError` fallback (confirmed applied — the mutated region was printed before the run) fails `test_read_only_file_is_parsed_and_left_intact`; restoring it passes.
