### PR TITLE
fix: stop trusting $PATH, /tmp and external text while running as root

### DIFF
--- a/mxtop/export.py
+++ b/mxtop/export.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import csv
 import json
+import os
 from pathlib import Path
 from typing import Any, TextIO
 
@@ -39,6 +40,22 @@ def sample_row(
     }
 
 
+def _give_back_to_sudo_user(fh: TextIO) -> None:
+    """Hand a file created under ``sudo mxtop`` back to the invoking user.
+
+    Otherwise every export is root-owned and the user cannot edit or delete it
+    without sudo. Uses ``fchown`` on the open handle, so a symlinked target
+    cannot redirect the ownership change.
+    """
+    uid, gid = os.environ.get("SUDO_UID"), os.environ.get("SUDO_GID")
+    if not (uid and gid):
+        return
+    try:
+        os.fchown(fh.fileno(), int(uid), int(gid))
+    except OSError as exc:
+        logger.debug("could not chown the export file: {}", exc)
+
+
 class Exporter:
     """Append one record per sample to *path*.
 
@@ -60,6 +77,7 @@ class Exporter:
             )
         self.format = fmt
         self._fh: TextIO = self.path.open("w", newline="", encoding="utf-8")
+        _give_back_to_sudo_user(self._fh)
         self._writer: csv.DictWriter | None = None
         logger.info("Exporting samples to {} ({})", self.path, self.format)
 

--- a/mxtop/mxtop.py
+++ b/mxtop/mxtop.py
@@ -112,9 +112,17 @@ def main():
 
     print("\n[3/3] Waiting for first reading...\n")
 
-    # Block until the first valid reading arrives
+    # Block until the first valid reading arrives. powermetrics writes to
+    # stderr=DEVNULL, so a failed start is otherwise indistinguishable from a
+    # slow one and this loop would spin forever.
     ready = None
     while ready is None:
+        if powermetrics_process.poll() is not None:
+            print("\033[?25h")  # restore cursor
+            raise SystemExit(
+                f"powermetrics exited with status {powermetrics_process.returncode} "
+                f"before producing a reading — try `sudo mxtop`."
+            )
         time.sleep(0.1)
         ready = parse_powermetrics(timecode=timecode)
     last_timestamp = ready[-1]

--- a/mxtop/system_info.py
+++ b/mxtop/system_info.py
@@ -45,7 +45,7 @@ def get_wifi_metrics() -> dict[str, Any]:
     # ---------- primary: system_profiler -----------------------------------
     try:
         proc = subprocess.run(
-            ["system_profiler", "SPAirPortDataType", "-detailLevel", "basic"],
+            ["/usr/sbin/system_profiler", "SPAirPortDataType", "-detailLevel", "basic"],
             capture_output=True,
             text=True,
             timeout=10,
@@ -80,7 +80,7 @@ def get_wifi_metrics() -> dict[str, Any]:
     if result["ssid"] is None:
         try:
             proc = subprocess.run(
-                ["networksetup", "-getairportnetwork", "en0"],
+                ["/usr/sbin/networksetup", "-getairportnetwork", "en0"],
                 capture_output=True,
                 text=True,
                 timeout=5,
@@ -197,7 +197,7 @@ def get_power_metrics() -> dict[str, Any]:
     # --- pmset -g batt (works without sudo) ---
     try:
         proc = subprocess.run(
-            ["pmset", "-g", "batt"],
+            ["/usr/bin/pmset", "-g", "batt"],
             capture_output=True,
             text=True,
             timeout=5,
@@ -239,7 +239,7 @@ def get_power_metrics() -> dict[str, Any]:
     # --- system_profiler for charger details ---
     try:
         proc = subprocess.run(
-            ["system_profiler", "SPPowerDataType", "-detailLevel", "basic"],
+            ["/usr/sbin/system_profiler", "SPPowerDataType", "-detailLevel", "basic"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/mxtop/updater.py
+++ b/mxtop/updater.py
@@ -25,6 +25,18 @@ def _cap_chart(chart: HChart, maxlen: int = _MAX_CHART_POINTS) -> None:
         chart.datapoints = chart.datapoints[-maxlen:]
 
 
+def _printable(text: Any) -> str:
+    """Drop control characters before rendering externally-supplied text.
+
+    Process names, WiFi SSIDs and USB-C adapter names are all chosen by
+    someone other than the user running mxtop, and land straight in a terminal
+    that mxtop often drives as root.  ``str.isprintable()`` is False for ESC,
+    newlines and tabs, so this strips escape sequences and table-breaking
+    whitespace in one pass.
+    """
+    return "".join(c for c in str(text) if c.isprintable())
+
+
 def _format_bytes(b: int) -> str:
     """Human-readable byte size (e.g. 1.2 GB, 340 MB)."""
     for unit in ("B", "KB", "MB", "GB", "TB"):
@@ -184,7 +196,7 @@ def update_wifi_widget(w: dict[str, Any], wifi: dict[str, Any]) -> None:
         signal_pct = max(0, min(100, int((rssi + 90) / 60 * 100)))
         rate_str = f" {wifi['tx_rate_Mbps']:.0f} Mbps" if wifi["tx_rate_Mbps"] else ""
         w["wifi_gauge"].title = (
-            f"WiFi: {wifi['ssid']}  {rssi} dBm ({signal_pct}%){rate_str}"
+            f"WiFi: {_printable(wifi['ssid'])}  {rssi} dBm ({signal_pct}%){rate_str}"
         )
         w["wifi_gauge"].value = signal_pct
     else:
@@ -216,7 +228,7 @@ def update_power_widgets(w: dict[str, Any], pwr: dict[str, Any]) -> None:
     # Charger gauge
     if pwr["cable_connected"]:
         watt_str = f"{pwr['wattage']}W" if pwr["wattage"] else "?"
-        name_str = pwr["adapter_name"] or "Unknown adapter"
+        name_str = _printable(pwr["adapter_name"] or "Unknown adapter")
         w["charger_gauge"].title = f"Charger: {name_str} ({watt_str}) — cable connected"
         w["charger_gauge"].value = 100
     else:
@@ -278,7 +290,7 @@ def update_top_widget(w: dict[str, Any], top: list[dict[str, Any]]) -> None:
         return
     widget.text = "\n".join(
         f"{row['cpu_percent']:5.1f}% {_format_bytes(row['rss']):>9}  "
-        f"{row['name'][:18]}"
+        f"{_printable(row['name'])[:18]}"
         for row in top
     )
 

--- a/mxtop/utils.py
+++ b/mxtop/utils.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import glob
 import os
 import plistlib
+import stat
 import subprocess
+import tempfile
 from typing import Any
 
 import psutil
@@ -45,6 +47,18 @@ _SOC_DEFAULT = {"cpu": 20, "gpu": 20, "cpu_bw": 70, "gpu_bw": 70}
 
 
 # ---------------------------------------------------------------------------
+# Temp file location
+# ---------------------------------------------------------------------------
+
+# powermetrics runs as root and writes here, and we read the file back and
+# truncate it — also as root under `sudo mxtop`.  A predictable name in the
+# world-writable /tmp let any local user plant a symlink there and have root
+# overwrite the target.  mkdtemp gives an unguessable 0700 directory instead.
+_TMP_DIR = tempfile.mkdtemp(prefix="mxtop-")
+_TMP_PREFIX = os.path.join(_TMP_DIR, "powermetrics")
+
+
+# ---------------------------------------------------------------------------
 # Powermetrics file parsing
 # ---------------------------------------------------------------------------
 
@@ -52,7 +66,7 @@ _READ_TAIL_BYTES = 64 * 1024  # only read the last 64 KiB of the file
 
 
 def parse_powermetrics(
-    path: str = "/tmp/mxtop_powermetrics",
+    path: str = _TMP_PREFIX,
     timecode: str = "0",
 ) -> tuple[dict, dict, str, None, Any] | None:
     """Parse the plist written by powermetrics.
@@ -68,22 +82,33 @@ def parse_powermetrics(
     ``powermetrics`` always runs as root, so without ``sudo mxtop`` the file
     belongs to root and cannot be opened for writing.  That is not fatal: the
     file is then read read-only and left untouched.
+
+    The file is opened with ``O_NOFOLLOW`` and must be a regular file: we
+    truncate and rewrite it as root, so following a symlink here would let a
+    local user redirect that write anywhere on the system.
     """
     filepath = path + timecode
     writable = True
     try:
-        fd = os.open(filepath, os.O_RDWR)
+        fd = os.open(filepath, os.O_RDWR | os.O_NOFOLLOW)
     except FileNotFoundError:
         return None
     except PermissionError:
         try:
-            fd = os.open(filepath, os.O_RDONLY)
+            fd = os.open(filepath, os.O_RDONLY | os.O_NOFOLLOW)
         except OSError:
             return None
         writable = False
+    except OSError as exc:  # ELOOP — the path is a symlink
+        logger.warning("refusing to read {}: {}", filepath, exc)
+        return None
 
     try:
-        file_size = os.fstat(fd).st_size
+        st = os.fstat(fd)
+        if not stat.S_ISREG(st.st_mode):
+            logger.warning("refusing to read {}: not a regular file", filepath)
+            return None
+        file_size = st.st_size
         if file_size == 0:
             return None
 
@@ -132,7 +157,9 @@ def _keep_only_last_blob(fd: int, chunk: bytes) -> None:
 # ---------------------------------------------------------------------------
 
 def clear_console() -> None:
-    os.system("clear")
+    # ANSI erase-screen + cursor-home. Not `os.system("clear")`: that spawns a
+    # shell and resolves `clear` through $PATH, which mxtop runs as root.
+    print("\033[2J\033[H", end="", flush=True)
 
 
 def _bytes_to_gb(value: int | float) -> float:
@@ -143,16 +170,17 @@ def _bytes_to_gb(value: int | float) -> float:
 # Subprocess management
 # ---------------------------------------------------------------------------
 
-_TMP_PREFIX = "/tmp/mxtop_powermetrics"
-
-
 def cleanup_tmp_files() -> None:
-    """Remove leftover powermetrics temp files."""
+    """Remove leftover powermetrics temp files and the directory holding them."""
     for f in glob.glob(f"{_TMP_PREFIX}*"):
         try:
             os.remove(f)
         except OSError:
             pass
+    try:
+        os.rmdir(_TMP_DIR)
+    except OSError:
+        pass
 
 
 def run_powermetrics_process(
@@ -162,9 +190,12 @@ def run_powermetrics_process(
 ) -> subprocess.Popen:
     """Spawn ``powermetrics`` as a background process writing to a temp file."""
     cleanup_tmp_files()
+    os.makedirs(_TMP_DIR, mode=0o700, exist_ok=True)
+    # Absolute paths: this runs as root, and macOS sudo does not set
+    # secure_path, so $PATH is still the invoking user's.
     cmd = [
-        "sudo", "nice", f"-n{nice}",
-        "powermetrics",
+        "/usr/bin/sudo", "/usr/bin/nice", f"-n{nice}",
+        "/usr/bin/powermetrics",
         "--samplers", "cpu_power,gpu_power,thermal",
         "-o", f"{_TMP_PREFIX}{timecode}",
         "-f", "plist",
@@ -217,7 +248,7 @@ def _run_sysctl(key: str) -> str | None:
     """Fetch a single sysctl value, returning None on failure."""
     try:
         result = subprocess.run(
-            ["sysctl", "-n", key],
+            ["/usr/sbin/sysctl", "-n", key],
             capture_output=True, text=True, timeout=5,
         )
         return result.stdout.strip() or None
@@ -241,7 +272,7 @@ def _get_core_counts() -> tuple[int, int]:
 def _get_gpu_cores() -> int | str:
     try:
         result = subprocess.run(
-            ["system_profiler", "-detailLevel", "basic", "SPDisplaysDataType"],
+            ["/usr/sbin/system_profiler", "-detailLevel", "basic", "SPDisplaysDataType"],
             capture_output=True, text=True, timeout=10,
         )
         for line in result.stdout.splitlines():

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -1,0 +1,92 @@
+"""Regression tests for the root-privilege hardening."""
+
+import os
+import plistlib
+import stat
+
+from mxtop.utils import _TMP_DIR, _TMP_PREFIX, parse_powermetrics
+from mxtop.updater import _printable, update_top_widget, update_wifi_widget
+
+
+def _valid_plist() -> bytes:
+    return plistlib.dumps({
+        "timestamp": "now",
+        "processor": {
+            "clusters": [{
+                "name": "E-Cluster", "idle_ratio": 0.5, "freq_hz": 1e9,
+                "cpus": [{"cpu": 0, "idle_ratio": 0.5, "freq_hz": 1e9}],
+            }],
+            "ane_energy": 0, "cpu_energy": 0, "gpu_energy": 0, "combined_power": 0,
+        },
+        "gpu": {"freq_hz": 1e9, "idle_ratio": 0.5},
+        "thermal_pressure": "Nominal",
+    })
+
+
+# --- temp file location ----------------------------------------------------
+
+def test_tmp_dir_is_private_and_unpredictable():
+    assert not _TMP_PREFIX.startswith("/tmp/mxtop_powermetrics")
+    mode = os.stat(_TMP_DIR).st_mode
+    assert stat.S_IMODE(mode) == 0o700
+    assert os.stat(_TMP_DIR).st_uid == os.geteuid()
+
+
+def test_symlinked_powermetrics_file_is_refused(tmp_path):
+    """A symlink in place of the temp file must not be read, let alone rewritten.
+
+    The victim holds *parseable* content followed by junk, so that without
+    O_NOFOLLOW the parser succeeds and truncates the file down to the plist —
+    which is exactly the root-owned overwrite this guards against.
+    """
+    original = _valid_plist() + b"\x00" + b"PADDING" * 100
+    victim = tmp_path / "victim"
+    victim.write_bytes(original)
+
+    prefix = str(tmp_path / "pm")
+    os.symlink(victim, prefix + "1")
+
+    assert parse_powermetrics(path=prefix, timecode="1") is None
+    assert victim.read_bytes() == original, "symlink target was rewritten"
+
+
+def test_regular_file_is_still_parsed(tmp_path):
+    prefix = str(tmp_path / "pm")
+    (tmp_path / "pm1").write_bytes(_valid_plist())
+
+    result = parse_powermetrics(path=prefix, timecode="1")
+    assert result is not None
+    assert result[-1] == "now"
+
+
+# --- untrusted text --------------------------------------------------------
+
+def test_printable_strips_escape_sequences():
+    assert _printable("\x1b]0;pwned\x07Safari") == "]0;pwnedSafari"
+    assert _printable("a\nb\tc") == "abc"
+    assert _printable("Wi-Fi Café 5GHz") == "Wi-Fi Café 5GHz"
+
+
+class _FakeWidget:
+    text = ""
+    title = ""
+    value = 0
+
+
+def test_process_name_escapes_never_reach_the_widget():
+    """A local user picks their own process name — it must not drive the terminal."""
+    w = {"top_text": _FakeWidget()}
+    update_top_widget(w, [{
+        "pid": 1, "name": "\x1b]0;pwned\x07evil", "cpu_percent": 1.0, "rss": 1024,
+    }])
+    assert "\x1b" not in w["top_text"].text
+
+
+def test_ssid_escapes_never_reach_the_widget():
+    """SSIDs come from whatever access point is nearby."""
+    w = {"wifi_gauge": _FakeWidget()}
+    update_wifi_widget(w, {
+        "connected": True, "ssid": "\x1b[2Jfree wifi", "rssi_dBm": -50,
+        "tx_rate_Mbps": None, "noise_dBm": None, "channel": None,
+    })
+    assert "\x1b" not in w["wifi_gauge"].title

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -4,6 +4,7 @@ import os
 import plistlib
 import stat
 
+from mxtop.export import Exporter
 from mxtop.utils import _TMP_DIR, _TMP_PREFIX, parse_powermetrics
 from mxtop.updater import _printable, update_top_widget, update_wifi_widget
 
@@ -90,3 +91,26 @@ def test_ssid_escapes_never_reach_the_widget():
         "tx_rate_Mbps": None, "noise_dBm": None, "channel": None,
     })
     assert "\x1b" not in w["wifi_gauge"].title
+
+
+# --- export file ownership -------------------------------------------------
+
+def test_export_file_is_handed_back_to_the_sudo_user(tmp_path, monkeypatch):
+    """Under sudo the export must not stay root-owned."""
+    calls = []
+    monkeypatch.setenv("SUDO_UID", str(os.getuid()))
+    monkeypatch.setenv("SUDO_GID", str(os.getgid()))
+    monkeypatch.setattr(os, "fchown", lambda fd, uid, gid: calls.append((uid, gid)))
+
+    Exporter(tmp_path / "out.csv").close()
+    assert calls == [(os.getuid(), os.getgid())]
+
+
+def test_export_file_untouched_without_sudo(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.delenv("SUDO_UID", raising=False)
+    monkeypatch.delenv("SUDO_GID", raising=False)
+    monkeypatch.setattr(os, "fchown", lambda fd, uid, gid: calls.append((uid, gid)))
+
+    Exporter(tmp_path / "out.csv").close()
+    assert calls == []

--- a/tests/test_system_info.py
+++ b/tests/test_system_info.py
@@ -40,7 +40,7 @@ class TestGetWifiMetrics:
     def test_connected_via_legacy_airport(self, mock_run):
         """Falls back to legacy airport -I when system_profiler has no data."""
         def side_effect(cmd, **kw):
-            if "system_profiler" in cmd:
+            if any("system_profiler" in c for c in cmd):
                 return MagicMock(returncode=0, stdout="Wi-Fi:\n")
             if "airport" in cmd[0]:
                 return MagicMock(
@@ -90,7 +90,7 @@ class TestGetPowerMetrics:
     @patch("mxtop.system_info.subprocess.run")
     def test_ac_power(self, mock_run):
         def side_effect(cmd, **kw):
-            if "pmset" in cmd:
+            if any("pmset" in c for c in cmd):
                 return MagicMock(
                     returncode=0,
                     stdout=(
@@ -119,7 +119,7 @@ class TestGetPowerMetrics:
     @patch("mxtop.system_info.subprocess.run")
     def test_battery_power(self, mock_run):
         def side_effect(cmd, **kw):
-            if "pmset" in cmd:
+            if any("pmset" in c for c in cmd):
                 return MagicMock(
                     returncode=0,
                     stdout=(


### PR DESCRIPTION
## What

Five hardening fixes for the fact that mxtop runs as root under `sudo mxtop`, and takes input from places a local unprivileged user controls: the temp file path, `$PATH`, and the text it renders into the terminal.

## Why

Found while auditing the repo. Nothing here needs remote access — every issue is reachable by any local user on the same Mac.

**1. Root-privileged write through a predictable path in `/tmp`.** `powermetrics -o /tmp/mxtop_powermetrics<int(time.time())>` runs as root, and `parse_powermetrics` reopens that path `O_RDWR` — no `O_NOFOLLOW` — then `ftruncate(fd, 0)` and rewrites it, also as root. The name is fully predictable, `/tmp` is world-writable, and the sticky bit only stops deleting *other* people's files, not creating your own symlink. Reproduced against `main` (run as a normal user, on files I own — same code path root takes):

```
victim size before : 580 bytes
victim size after  : 498 bytes
victim is now a plist written by mxtop: True
```

The bytes written are the last chunk `plistlib.loads` accepted, i.e. a plist the attacker wrote. Pointed at a `/Library/LaunchDaemons/*.plist`, that is root code execution at next login; at minimum it is arbitrary root file truncation.

**2. Every helper binary resolved through `$PATH` while root.** `os.system("clear")`, `nice`, `powermetrics`, `sysctl`, `system_profiler`, `pmset`, `networksetup`. macOS sudoers does not set `secure_path`, so `sudo mxtop` keeps the invoking user's `PATH`. A writable directory early in it — a stale `~/bin`, a project `.venv/bin`, a compromised Homebrew prefix — gets executed as root. `os.system` also spawns `/bin/sh` for something one `print` does.

**3. Untrusted text rendered straight into the terminal.** Three sources, none of them chosen by the person running mxtop:

| widget | source | who controls it |
|---|---|---|
| top processes | `psutil` process name | any local user (`exec -a $'\e]0;…\a'`) |
| WiFi | SSID | whoever operates a nearby access point |
| charger | `pmset` adapter name | whatever is plugged into the USB-C port |

Escape sequences reach a terminal that mxtop often drives as root — title spoofing, screen manipulation, and worse on terminals with clipboard or response sequences enabled.

**5. Startup hangs forever instead of reporting failure.** `while ready is None: time.sleep(0.1)` with `stderr=subprocess.DEVNULL` on the child. Any powermetrics failure — permission denied, tampered file — presents as a permanent freeze on `[3/3] Waiting for first reading...`. Not a vulnerability itself, but it is how the failures above would surface.

## How

| # | fix | file |
|---|---|---|
| 1 | `tempfile.mkdtemp(prefix="mxtop-")` — unguessable, 0700, root-owned — replaces the `/tmp` prefix; `os.open(..., O_NOFOLLOW)` plus an `S_ISREG` check on the fd | `utils.py` |
| 2 | absolute paths at every call site; `clear_console()` prints `\033[2J\033[H` | `utils.py`, `system_info.py` |
| 3 | one `_printable()` helper, applied at all three render sites | `updater.py` |
| 4 | `fchown` on the open handle back to `SUDO_UID`/`SUDO_GID` | `export.py` |
| 5 | `powermetrics_process.poll()` in the wait loop, `SystemExit` with the child's status | `mxtop.py` |

Fix 1 is defence in depth on purpose: the private directory alone closes it, and `O_NOFOLLOW` + `S_ISREG` keep it closed if anyone later points `path=` somewhere shared.

**Rejected:** dropping privileges before the read. `powermetrics` genuinely needs root and the file is root-owned; `preexec_fn` is documented as unsafe in a threaded process, which mxtop is. Making the file unreachable is simpler than making the read safe.

**Deliberately not included:** the `os.geteuid() != 0` guard around `sudo`. That is #8's change and belongs to @TTAAAN — this PR only makes the existing `sudo` absolute, so the two do not fight. #7 also touches `system_info.py`; conflicts there are one-line path changes.

## Comparison

| | before | after |
|---|---|---|
| temp file | `/tmp/mxtop_powermetrics<epoch>`, world-writable dir, guessable | `<mkdtemp>/powermetrics<epoch>`, 0700, unguessable |
| symlink at that path | followed, truncated, rewritten as root | refused, logged, target untouched |
| binaries | `$PATH` lookup as root | absolute paths |
| `clear_console` | `os.system("clear")` → `/bin/sh` → `$PATH` | one `print()`, no subprocess |
| `\x1b` in a process name / SSID / adapter name | reaches the terminal | stripped |
| `--export` under sudo | root-owned file the user cannot edit or delete | owned by the invoking user |
| powermetrics fails to start | hangs forever | exits with the status and a hint |

## Validation

```
uv run --group test pytest tests/ -q       # 93 passed
```

Eight tests in `tests/test_hardening.py`: temp dir mode/ownership/unpredictability, symlink refusal, regular files still parsed, escape-stripping at the helper *and* at both widget call sites, and the export chown with and without `SUDO_UID` set.

Mutation-checked — each fix reverted in turn, confirming the mutation applied before trusting the run:

| mutation | result |
|---|---|
| drop `O_NOFOLLOW` + the `S_ISREG` check | `test_symlinked_powermetrics_file_is_refused` fails |
| `_printable` → identity | 3 tests fail (helper + both call sites) |
| `mkdtemp` → a fixed `/tmp` path | `test_tmp_dir_is_private_and_unpredictable` fails |
| drop the `_give_back_to_sudo_user` call | `test_export_file_is_handed_back_to_the_sudo_user` fails |

The symlink test needed a second pass: the first version put junk in the victim file, so the parser bailed before reaching the truncate and the test passed even with `O_NOFOLLOW` removed. It now seeds the victim with a *parseable* plist plus padding, so an unguarded read really does rewrite it.

Two changes have no test: `clear_console()` (one line, no branch) and the `poll()` guard (would need `main()` stubbed end to end).

`tests/test_system_info.py` matched commands with `"pmset" in cmd` on the argv list, which is an exact element match and broke on absolute paths — switched to `any("pmset" in c for c in cmd)`.
